### PR TITLE
Bump loader.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "loader.js": "3.2.0"
   },
-  "version": "0.1.3",
+  "version": "0.1.5",
   "homepage": "https://github.com/paddle8/dom-ruler",
   "authors": [
     "Tim Evans <tim.evans@paddle8.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "dom-ruler",
   "dependencies": {
-    "loader.js": "1.0.1"
+    "loader.js": "3.2.0"
   },
   "version": "0.1.3",
   "homepage": "https://github.com/paddle8/dom-ruler",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-ruler",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "directories": {
     "doc": "doc",
     "test": "test"


### PR DESCRIPTION
This bumps the loader.js dependency for this package to make it compatible with `ember-cli@0.2.3`
